### PR TITLE
fix(cookieService): properly close the file

### DIFF
--- a/cookieproxy.go
+++ b/cookieproxy.go
@@ -80,12 +80,6 @@ func cookieService() {
 			return
 		}
 
-		defer func() {
-			if err = f.Close(); err != nil {
-				log.Fatal(err)
-			}
-		}()
-
 		// FIXME: there is a small chance of a race condition here
 		waitgroup.Add(1)
 		cookies = nil
@@ -116,6 +110,9 @@ func cookieService() {
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		f.Close()
+
 		time.Sleep(time.Duration(120) * time.Second)
 	}
 }


### PR DESCRIPTION
The old version of this routine would leave a bunch of dangling file
handles because it used `defer` to close the cookiejar. However, the
`cookieService` goroutine never exited, it just went to sleep and looped
over again. This force closes the cookiejar after reading it, preventing
an explosion of file handles.

Closes #1

DCO-1.1-Signed-off-by: Patrick Wagstrom <patrick@wagstrom.net>